### PR TITLE
Buildfix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -526,7 +526,7 @@ include Makefile.common
 OBJECTS := $(SOURCES_CXX:.cpp=.o) $(SOURCES_C:.c=.o) $(SOURCES_ASM:.s=.o)
 
 ifeq ($(DEBUG),1)
-FLAGS += -O0
+FLAGS += -O0 -g
 else
 FLAGS += -O2 -DNDEBUG
 endif

--- a/cz80.cpp
+++ b/cz80.cpp
@@ -74,7 +74,7 @@ u32 Cz80_Reset(cz80_struc *cpu)
 {
     cz80_struc *CPU = cpu;
     
-    fast_memset(CPU, 0, (u32*)(&(CPU->CycleSup)) - (u32*)(&(CPU->BC)));
+    fast_memset(CPU, 0, (uintptr_t)(&(CPU->CycleSup)) - (uintptr_t)(&(CPU->BC)));
 
     Cz80_Set_PC(CPU, 0);
     zIX = 0xFFFF;

--- a/cz80.h
+++ b/cz80.h
@@ -2,7 +2,7 @@
 /*                                                                              */
 /* CZ80 include file                                                            */
 /* C Z80 emulator version 0.92                                                  */
-/* Copyright 2004-2005 St�phane Dallongeville                                   */
+/* Copyright 2004-2005 Stéphane Dallongeville                                   */
 /*                                                                              */
 /********************************************************************************/
 

--- a/cz80.inc
+++ b/cz80.inc
@@ -2,7 +2,7 @@
 /*                                                                              */
 /* CZ80 macro file                                                              */
 /* C Z80 emulator version 0.92                                                  */
-/* Copyright 2004-2005 Stéphane Dallongeville                                   */
+/* Copyright 2004-2005 StÃ©phane Dallongeville                                   */
 /*                                                                              */
 /********************************************************************************/
 
@@ -83,7 +83,7 @@ void cpu_writeport(int Port,int Value);
 #define zhSP            CPU->SP.B.H
 
 #define zPC             PC
-#define zRealPC         ((u32)(PC) - ((u32)mame4all_cz80_rom))
+#define zRealPC         ((uintptr_t)(PC) - ((uintptr_t)mame4all_cz80_rom))
 
 #define zI              CPU->I
 #define zIM             CPU->IM
@@ -120,20 +120,20 @@ void cpu_writeport(int Port,int Value);
     ((s8)(*zPC++))
 
 #define FETCH_BYTE(A)		\
-   A = (mame4all_cz80_ram[((unsigned)zPC)-((unsigned)mame4all_cz80_rom)]); \
+   A = (mame4all_cz80_ram[((uintptr_t)zPC)-((uintptr_t)mame4all_cz80_rom)]); \
    zPC++
 
 #define FETCH_BYTE_S(A)		\
-   A = ((s8)(mame4all_cz80_ram[((unsigned)zPC)-((unsigned)mame4all_cz80_rom)])); \
+   A = ((s8)(mame4all_cz80_ram[((uintptr_t)zPC)-((uintptr_t)mame4all_cz80_rom)])); \
    zPC++
 
 #if CZ80_LITTLE_ENDIAN
 #define FETCH_WORD(A) \
-    A= ((unsigned short)(mame4all_cz80_ram[((unsigned)zPC)-((unsigned)mame4all_cz80_rom)])) | (((unsigned short)(mame4all_cz80_ram[1+((unsigned)zPC)-((unsigned)mame4all_cz80_rom)])) << 8); 	\
+    A= ((unsigned short)(mame4all_cz80_ram[((uintptr_t)zPC)-((uintptr_t)mame4all_cz80_rom)])) | (((unsigned short)(mame4all_cz80_ram[1+((uintptr_t)zPC)-((uintptr_t)mame4all_cz80_rom)])) << 8); 	\
     zPC += 2
 #else
 #define FETCH_WORD(A) \
-    A= ((unsigned short)(mame4all_cz80_ram[1+((unsigned)zPC)-((unsigned)mame4all_cz80_rom)])) | (((unsigned short)(mame4all_cz80_ram[((unsigned)zPC)-((unsigned)mame4all_cz80_rom)])) << 8); 	\
+    A= ((unsigned short)(mame4all_cz80_ram[1+((uintptr_t)zPC)-((uintptr_t)mame4all_cz80_rom)])) | (((unsigned short)(mame4all_cz80_ram[((uintptr_t)zPC)-((uintptr_t)mame4all_cz80_rom)])) << 8); 	\
     zPC += 2
 #endif
 

--- a/cz80_op.inc
+++ b/cz80_op.inc
@@ -2,7 +2,7 @@
 /*                                                                              */
 /* CZ80 opcode include source file                                              */
 /* C Z80 emulator version 0.92                                                  */
-/* Copyright 2004-2005 Stéphane Dallongeville                                   */
+/* Copyright 2004-2005 StÃ©phane Dallongeville                                   */
 /*                                                                              */
 /********************************************************************************/
 
@@ -1016,56 +1016,56 @@ OP_RRA:
     OP(0xd2):   // JP   NC,nn
 OP_JP_NC:
         if (!(zF & CZ80_CF)) goto OP_JP;
-	newPC=(((unsigned)zPC)-((unsigned)mame4all_cz80_rom))+2;
+	newPC=(((uintptr_t)zPC)-((uintptr_t)mame4all_cz80_rom))+2;
 	SET_PC(newPC);
         RET(10);
 
     OP(0xda):   // JP   C,nn
 OP_JP_C:
         if (zF & CZ80_CF) goto OP_JP;
-	newPC=(((unsigned)zPC)-((unsigned)mame4all_cz80_rom))+2;
+	newPC=(((uintptr_t)zPC)-((uintptr_t)mame4all_cz80_rom))+2;
 	SET_PC(newPC);
         RET(10);
 
     OP(0xe2):   // JP   PO,nn
 OP_JP_PO:
         if (!(zF & CZ80_VF)) goto OP_JP;
-	newPC=(((unsigned)zPC)-((unsigned)mame4all_cz80_rom))+2;
+	newPC=(((uintptr_t)zPC)-((uintptr_t)mame4all_cz80_rom))+2;
 	SET_PC(newPC);
         RET(10);
 
     OP(0xea):   // JP   PE,nn
 OP_JP_PE:
         if (zF & CZ80_VF) goto OP_JP;
-	newPC=(((unsigned)zPC)-((unsigned)mame4all_cz80_rom))+2;
+	newPC=(((uintptr_t)zPC)-((uintptr_t)mame4all_cz80_rom))+2;
 	SET_PC(newPC);
         RET(10);
 
     OP(0xf2):   // JP   P,nn
 OP_JP_P:
         if (!(zF & CZ80_SF)) goto OP_JP;
-	newPC=(((unsigned)zPC)-((unsigned)mame4all_cz80_rom))+2;
+	newPC=(((uintptr_t)zPC)-((uintptr_t)mame4all_cz80_rom))+2;
 	SET_PC(newPC);
         RET(10);
 
     OP(0xfa):   // JP   M,nn
 OP_JP_M:
         if (zF & CZ80_SF) goto OP_JP;
-	newPC=(((unsigned)zPC)-((unsigned)mame4all_cz80_rom))+2;
+	newPC=(((uintptr_t)zPC)-((uintptr_t)mame4all_cz80_rom))+2;
 	SET_PC(newPC);
         RET(10);
 
     OP(0xca):   // JP   Z,nn
 OP_JP_Z:
         if (zF & CZ80_ZF) goto OP_JP;
-	newPC=(((unsigned)zPC)-((unsigned)mame4all_cz80_rom))+2;
+	newPC=(((uintptr_t)zPC)-((uintptr_t)mame4all_cz80_rom))+2;
 	SET_PC(newPC);
         RET(10);
 
     OP(0xc2):   // JP   NZ,nn
 OP_JP_NZ:
         if (!(zF & CZ80_ZF)) goto OP_JP;
-	newPC=(((unsigned)zPC)-((unsigned)mame4all_cz80_rom))+2;
+	newPC=(((uintptr_t)zPC)-((uintptr_t)mame4all_cz80_rom))+2;
 	SET_PC(newPC);
         RET(10);
 
@@ -1086,28 +1086,28 @@ OP_JP_xx:
     OP(0x38):   // JR   C,n
 OP_JR_C:
         if (zF & CZ80_CF) goto OP_JR;
-	newPC=(((unsigned)zPC)-((unsigned)mame4all_cz80_rom))+1;
+	newPC=(((uintptr_t)zPC)-((uintptr_t)mame4all_cz80_rom))+1;
 	SET_PC(newPC);
         RET(7)
 
     OP(0x30):   // JR   NC,n
 OP_JR_NC:
         if (!(zF & CZ80_CF)) goto OP_JR;
-	newPC=(((unsigned)zPC)-((unsigned)mame4all_cz80_rom))+1;
+	newPC=(((uintptr_t)zPC)-((uintptr_t)mame4all_cz80_rom))+1;
 	SET_PC(newPC);
         RET(7)
 
     OP(0x28):   // JR   Z,n
 OP_JR_Z:
         if (zF & CZ80_ZF) goto OP_JR;
-	newPC=(((unsigned)zPC)-((unsigned)mame4all_cz80_rom))+1;
+	newPC=(((uintptr_t)zPC)-((uintptr_t)mame4all_cz80_rom))+1;
 	SET_PC(newPC);
         RET(7)
 
     OP(0x20):   // JR   NZ,n
 OP_JR_NZ:
         if (!(zF & CZ80_ZF)) goto OP_JR;
-	newPC=(((unsigned)zPC)-((unsigned)mame4all_cz80_rom))+1;
+	newPC=(((uintptr_t)zPC)-((uintptr_t)mame4all_cz80_rom))+1;
 	SET_PC(newPC);
         RET(7)
 
@@ -1115,7 +1115,7 @@ OP_JR_NZ:
 OP_DJNZ:
         Z80_ICount--;
         if (--zB) goto OP_JR;
-	newPC=(((unsigned)zPC)-((unsigned)mame4all_cz80_rom))+1;
+	newPC=(((uintptr_t)zPC)-((uintptr_t)mame4all_cz80_rom))+1;
 	SET_PC(newPC);
         RET(9)
 
@@ -1126,7 +1126,7 @@ OP_JR:
 
         FETCH_BYTE_S(adr);
         // no rebase needed here...
-	newPC=(((unsigned)zPC)-((unsigned)mame4all_cz80_rom))+adr;
+	newPC=(((uintptr_t)zPC)-((uintptr_t)mame4all_cz80_rom))+adr;
 	SET_PC(newPC);
         RET(12)
     }
@@ -1136,56 +1136,56 @@ OP_JR:
     OP(0xd4):   // CALL NC,nn
 OP_CALL_NC:
         if (!(zF & CZ80_CF)) goto OP_CALL;
-	newPC=(((unsigned)zPC)-((unsigned)mame4all_cz80_rom))+2;
+	newPC=(((uintptr_t)zPC)-((uintptr_t)mame4all_cz80_rom))+2;
 	SET_PC(newPC);
         RET(10)
 
     OP(0xdc):   // CALL C,nn
 OP_CALL_C:
         if (zF & CZ80_CF) goto OP_CALL;
-	newPC=(((unsigned)zPC)-((unsigned)mame4all_cz80_rom))+2;
+	newPC=(((uintptr_t)zPC)-((uintptr_t)mame4all_cz80_rom))+2;
 	SET_PC(newPC);
         RET(10)
 
     OP(0xe4):   // CALL PO,nn
 OP_CALL_PO:
         if (!(zF & CZ80_VF)) goto OP_CALL;
-	newPC=(((unsigned)zPC)-((unsigned)mame4all_cz80_rom))+2;
+	newPC=(((uintptr_t)zPC)-((uintptr_t)mame4all_cz80_rom))+2;
 	SET_PC(newPC);
         RET(10)
 
     OP(0xec):   // CALL PE,nn
 OP_CALL_PE:
         if (zF & CZ80_VF) goto OP_CALL;
-	newPC=(((unsigned)zPC)-((unsigned)mame4all_cz80_rom))+2;
+	newPC=(((uintptr_t)zPC)-((uintptr_t)mame4all_cz80_rom))+2;
 	SET_PC(newPC);
         RET(10)
 
     OP(0xf4):   // CALL P,nn
 OP_CALL_P:
         if (!(zF & CZ80_SF)) goto OP_CALL;
-	newPC=(((unsigned)zPC)-((unsigned)mame4all_cz80_rom))+2;
+	newPC=(((uintptr_t)zPC)-((uintptr_t)mame4all_cz80_rom))+2;
 	SET_PC(newPC);
         RET(10)
 
     OP(0xfc):   // CALL M,nn
 OP_CALL_M:
         if (zF & CZ80_SF) goto OP_CALL;
-	newPC=(((unsigned)zPC)-((unsigned)mame4all_cz80_rom))+2;
+	newPC=(((uintptr_t)zPC)-((uintptr_t)mame4all_cz80_rom))+2;
 	SET_PC(newPC);
         RET(10)
 
     OP(0xcc):   // CALL Z,nn
 OP_CALL_Z:
         if (zF & CZ80_ZF) goto OP_CALL;
-	newPC=(((unsigned)zPC)-((unsigned)mame4all_cz80_rom))+2;
+	newPC=(((uintptr_t)zPC)-((uintptr_t)mame4all_cz80_rom))+2;
 	SET_PC(newPC);
         RET(10)
 
     OP(0xc4):   // CALL NZ,nn
 OP_CALL_NZ:
         if (!(zF & CZ80_ZF)) goto OP_CALL;
-	newPC=(((unsigned)zPC)-((unsigned)mame4all_cz80_rom))+2;
+	newPC=(((uintptr_t)zPC)-((uintptr_t)mame4all_cz80_rom))+2;
 	SET_PC(newPC);
         RET(10)
     }

--- a/libretro/libretro.cpp
+++ b/libretro/libretro.cpp
@@ -5,12 +5,13 @@
 #include "../StdAfx.h"
 #include "../state.h"
 #include "../neopopsound.h"
+#include "../sound.h"
 #include "../input.h"
 #include "../flash.h"
 #include "../tlcs900h.h"
 #include "../memory.h"
 #include "../graphics.h"
-#include "../neopopsound.h"
+#include "../state.h"
 
 static retro_log_printf_t log_cb;
 static retro_video_refresh_t video_cb;
@@ -311,8 +312,8 @@ void retro_run(void)
 
    memset(sampleBuffer, 0, samplesPerFrame * sizeof(int16_t));
 
-   sound_update((unsigned short*)sampleBuffer, samplesPerFrame * sizeof(int16_t)); //Get sound data
-   dac_update((unsigned short*)sampleBuffer, samplesPerFrame * sizeof(int16_t));
+   sound_update((uint16_t*)sampleBuffer, samplesPerFrame * sizeof(int16_t)); //Get sound data
+   dac_update((uint16_t*)sampleBuffer, samplesPerFrame * sizeof(int16_t));
 
    int16_t        *p        = stereoBuffer;
    for (int i = 0; i < samplesPerFrame; i++)

--- a/state.cpp
+++ b/state.cpp
@@ -171,7 +171,7 @@ static int state_store(race_state_t *rs)
   extern cz80_struc *RACE_cz80_struc;
   extern s32 Z80_ICount;
   int size_of_z80 = 
-    (u32*)(&(RACE_cz80_struc->CycleSup)) - (u32*)(&(RACE_cz80_struc->BC));
+    (uintptr_t)(&(RACE_cz80_struc->CycleSup)) - (uintptr_t)(&(RACE_cz80_struc->BC));
   memcpy(&rs->RACE_cz80_struc, RACE_cz80_struc, size_of_z80);
   rs->Z80_ICount = Z80_ICount;
   rs->PC_offset = Cz80_Get_PC(RACE_cz80_struc);
@@ -245,7 +245,7 @@ static int state_restore(race_state_t *rs)
   extern cz80_struc *RACE_cz80_struc;
   extern s32 Z80_ICount;
   int size_of_z80 = 
-    (u32*)(&(RACE_cz80_struc->CycleSup)) - (u32*)(&(RACE_cz80_struc->BC));
+    (uintptr_t)(&(RACE_cz80_struc->CycleSup)) - (uintptr_t)(&(RACE_cz80_struc->BC));
 
   memcpy(RACE_cz80_struc, &rs->RACE_cz80_struc, size_of_z80);
   Z80_ICount = rs->Z80_ICount;

--- a/tlcs900h.cpp
+++ b/tlcs900h.cpp
@@ -736,7 +736,8 @@ unsigned int gen_regsPC, gen_regsSR;
 #endif
 
 // declare ldc registers
-unsigned char __attribute__ ((__aligned__(4))) ldcRegs[64];
+// 12-29-19 FIXME: should be aligned, but this crashes save states
+unsigned char /*__attribute__ ((__aligned__(4))) */ldcRegs[64];
 
 // declare struct for easy access to flags of flag register
 //struct SR0 {


### PR DESCRIPTION
fixes ios build and clang

thanks to @msperson from discord and @twinaphex 

This line needs another set of eyes. alignment is commented out here because its causing save state crash after the changes.
https://github.com/libretro/RACE/compare/master...negativeExponent:cpu?expand=1#diff-391d465b59fdb515fcb3212c9e6ec916R740

tested under linux-x64