### PR TITLE
prevent potential memory leak and fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -535,6 +535,11 @@ ifeq (,$(findstring msvc,$(platform)))
 FLAGS += -fomit-frame-pointer
 endif
 
+ifneq ($(SANITIZER),)
+FLAGS += -fsanitize=$(SANITIZER)
+LDFLAGS += -fsanitize=$(SANITIZER)
+endif
+
 FLAGS += -I. $(fpic) $(libs) $(includes) -DWANT_CRC32
 CXXFLAGS += $(FLAGS) $(INCFLAGS) $(INCFLAGS_PLATFORM)
 CFLAGS += $(FLAGS) $(INCFLAGS) $(INCFLAGS_PLATFORM)

--- a/graphics.cpp
+++ b/graphics.cpp
@@ -55,7 +55,7 @@ unsigned short drawBuffer[NGPC_SIZEX*NGPC_SIZEY];
 
 #else
 
-unsigned short *drawBuffer;
+static unsigned short *drawBuffer;
 
 #endif
 

--- a/graphics.h
+++ b/graphics.h
@@ -71,7 +71,7 @@ void graphics_debug(FILE *f);
 
 extern unsigned short palettes[16*4+16*4+16*4]; // placeholder for the converted palette
 extern int    totalpalette[32*32*32];
-#define NGPC_TO_SDL16(col) totalpalette[col]
+#define NGPC_TO_SDL16(col) totalpalette[col & 0x0FFF]
 
 #define setColPaletteEntry(addr, data) palettes[(addr)] = NGPC_TO_SDL16(data)
 #define setBWPaletteEntry(addr, data) palettes[(addr)] = NGPC_TO_SDL16(data)

--- a/libretro/libretro.cpp
+++ b/libretro/libretro.cpp
@@ -413,6 +413,13 @@ bool retro_load_game_special(unsigned, const struct retro_game_info*, size_t)
 void retro_unload_game(void)
 {
    initialized = false;
+
+   if (screen)
+   {
+      if (screen->pixels)
+         free(screen->pixels);
+      free(screen);
+   }
 }
 
 void retro_cheat_reset(void)

--- a/memory.cpp
+++ b/memory.cpp
@@ -57,6 +57,8 @@ unsigned char __attribute__ ((__aligned__(4))) mainrom[4*1024*1024];
 unsigned char __attribute__ ((__aligned__(4))) cpurom[256*1024];//prob only needs 0x10000
 //
 unsigned char __attribute__ ((__aligned__(4))) *cpuram;
+// declare ldc registers
+unsigned char __attribute__ ((__aligned__(4))) ldcRegs[64];
 
 //
 // preliminary address map:

--- a/tlcs900h.cpp
+++ b/tlcs900h.cpp
@@ -735,10 +735,6 @@ unsigned int gen_regsPC, gen_regsSR;
 //#define gen_regsSRb ((unsigned char *)&gen_regsSR)[0]//lsbyte of gen_regsSR
 #endif
 
-// declare ldc registers
-// 12-29-19 FIXME: should be aligned, but this crashes save states
-unsigned char /*__attribute__ ((__aligned__(4))) */ldcRegs[64];
-
 // declare struct for easy access to flags of flag register
 //struct SR0 {
 // unsigned int C0:1;


### PR DESCRIPTION
- Fix for inconsistent palette
- Workaround for savestate crash when compiling with clang
- Prevent potential memory leak
- Update Makefile to support compiling with asan

Reference : https://github.com/libretro/RACE/issues/6

Happy New Year Update!