### PR TITLE
Fix language core option

### DIFF
--- a/libretro/libretro.cpp
+++ b/libretro/libretro.cpp
@@ -93,10 +93,12 @@ static void check_variables(void)
    if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
    {
       // user must manually restart core for change to happen
+      // > 0: English
+      // > 1: Japanese
       if (!strcmp(var.value, "japanese"))
-         setting_ngp_language = 0;
-      else if (!strcmp(var.value, "english"))
          setting_ngp_language = 1;
+      else if (!strcmp(var.value, "english"))
+         setting_ngp_language = 0;
    }
 
    var.key = "race_sound_sample_rate";


### PR DESCRIPTION
The `Language` core option is currently inverted.

This trivial PR fixes the issue  :)