### PR TITLE
Fix input mapping typo

### DIFF
--- a/libretro/libretro.cpp
+++ b/libretro/libretro.cpp
@@ -55,7 +55,7 @@ static map btn_map[] = {
    { RETRO_DEVICE_ID_JOYPAD_LEFT, 0x04 },
    { RETRO_DEVICE_ID_JOYPAD_UP, 0x01 },
    { RETRO_DEVICE_ID_JOYPAD_DOWN, 0x02 },
-   { RETRO_DEVICE_ID_JOYPAD_SELECT, 0x40 },
+   { RETRO_DEVICE_ID_JOYPAD_START, 0x40 },
 };
 
 unsigned retro_api_version(void)


### PR DESCRIPTION
`libretro.cpp` contains a typo: At present, the NGP `Option` button is hardwired to `RetroPad SELECT`, whereas the input descriptor uses `RetroPad START`. This means the mapping is described incorrectly in the frontend, and the `Option` button cannot be remapped.

This trivial PR fixes the issue - now `RetroPad START` is used correctly in all cases :)