### PR TITLE
Add OpenDingux target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -327,6 +327,18 @@ else ifeq ($(platform), emscripten)
 	TARGET := $(TARGET_NAME)_libretro_$(platform).bc
 	STATIC_LINKING = 1
 
+# GCW0
+else ifeq ($(platform), gcw0)
+   TARGET := $(TARGET_NAME)_libretro.so
+   CC = /opt/gcw0-toolchain/usr/bin/mipsel-linux-gcc
+   CXX = /opt/gcw0-toolchain/usr/bin/mipsel-linux-g++
+   AR = /opt/gcw0-toolchain/usr/bin/mipsel-linux-ar
+   fpic := -fPIC
+   SHARED := -shared -Wl,-version-script=$(LIBRETRO_DIR)/link.T
+   PLATFORM_DEFINES := -DCC_RESAMPLER -DCC_RESAMPLER_NO_HIGHPASS
+   CFLAGS += -fomit-frame-pointer -ffast-math -march=mips32 -mtune=mips32r2 -mhard-float
+   CXXFLAGS += $(CFLAGS)
+
 # Windows MSVC 2010 x64
 else ifeq ($(platform), windows_msvc2010_x64)
 	CC  = cl.exe


### PR DESCRIPTION
This PR adds an OpenDingux (GCW0) target to the makefile.

Tested on an RG350M, the core runs perfectly with the following caveat: when using the internal IPU hardware scaler, running content at the native resolution causes display corruption (because the IPU cannot handle the NGP's peculiar screen dimensions). Applying any video filter corrects the issue (and a video filter is mandatory anyway, to avoid extreme blurring).

I will attempt to fix the native resolution corruption on the frontend side at a later date.