### PR TITLE
Add 'LOW_MEMORY' build flag to force content loading from file on RAM-limited platforms

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
 WANT_ZIP=0
+LOW_MEMORY=0
 
 TARGET_NAME := race
 GIT_VERSION := " $(shell git rev-parse --short HEAD || echo unknown)"
@@ -333,6 +334,7 @@ else ifeq ($(platform), rs90)
    PLATFORM_DEFINES := -DCC_RESAMPLER -DCC_RESAMPLER_NO_HIGHPASS
    CFLAGS += -fomit-frame-pointer -ffast-math -march=mips32 -mtune=mips32
    CXXFLAGS += $(CFLAGS)
+   LOW_MEMORY = 1
 
 # GCW0
 else ifeq ($(platform), gcw0)
@@ -564,6 +566,10 @@ endif
 
 ifeq ($(WANT_ZIP),1)
 FLAGS += -DWANT_ZIP
+endif
+
+ifeq ($(LOW_MEMORY), 1)
+FLAGS += -DLOW_MEMORY
 endif
 
 ifeq (,$(findstring msvc,$(platform)))

--- a/libretro/libretro.c
+++ b/libretro/libretro.c
@@ -141,7 +141,11 @@ void retro_set_environment(retro_environment_t cb)
    static const struct retro_system_content_info_override content_overrides[] = {
       {
          RACE_EXTENSIONS, /* extensions */
+#if defined(LOW_MEMORY)
+         true,            /* need_fullpath */
+#else
          false,           /* need_fullpath */
+#endif
          false            /* persistent_data */
       },
       { NULL, false, false }
@@ -333,9 +337,10 @@ bool retro_load_game(const struct retro_game_info *info)
    /* Attempt to fetch extended game info */
    if (environ_cb(RETRO_ENVIRONMENT_GET_GAME_INFO_EXT, &info_ext))
    {
+#if !defined(LOW_MEMORY)
       content_data = (const unsigned char *)info_ext->data;
       content_size = info_ext->size;
-
+#endif
       if (info_ext->file_in_archive)
       {
          /* We don't have a 'physical' file in this
@@ -358,9 +363,6 @@ bool retro_load_game(const struct retro_game_info *info)
    {
       if (!info || !info->path)
          return false;
-
-      content_data = NULL;
-      content_size = 0;
 
       strncpy(content_path, info->path, sizeof(content_path));
       content_path[sizeof(content_path) - 1] = '\0';


### PR DESCRIPTION
This PR adds a `LOW_MEMORY` build flag which forces the core to set `need_fullpath = true` - meaning that ROM data will be read directly from file rather than being passed as a frontend-provided data buffer. This is helpful on very low memory platforms, where the use of an 'external' memory buffer (which must be duplicated in the core) may exceed the total system RAM.

At present, this flag is only enabled for the RS-90 build. Note that the core is at present too slow for effective use on this device - I will look into adding a frameskip option as time permits...