### PR TITLE
Add optional frameskipping

### DIFF
--- a/graphics.c
+++ b/graphics.c
@@ -1314,8 +1314,7 @@ void myGraphicsBlitLine(unsigned char render)  /* NOTA */
         {
             /* start VBlank period */
             tlcsMemWriteB(0x00008010,tlcsMemReadB(0x00008010) | 0x40);
-            if (render)
-                graphics_paint();
+            graphics_paint(render);
         }
         *scanlineY+= 1;
     }

--- a/graphics.h
+++ b/graphics.h
@@ -60,7 +60,7 @@ extern unsigned short *oowTable;
 extern unsigned char *color_switch;
 
 BOOL graphics_init(void);
-void graphics_paint(void);
+void graphics_paint(unsigned char render);
 void graphicsSetDarkFilterLevel(unsigned filterLevel);
 /* new renderer (NeoGeo Pocket (Color)) */
 void myGraphicsBlitLine(unsigned char render);

--- a/libretro/libretro_core_options.h
+++ b/libretro/libretro_core_options.h
@@ -51,7 +51,7 @@ extern "C" {
 struct retro_core_option_definition option_defs_us[] = {
    {
       "race_language",
-      "Language",
+      "Language (Restart)",
       "Specify which language to display when running content with dual language support.",
       {
          { "japanese", "Japanese" },
@@ -79,6 +79,43 @@ struct retro_core_option_definition option_defs_us[] = {
          { NULL, NULL },
       },
       "0"
+   },
+   {
+      "race_frameskip",
+      "Frameskip",
+      "Skip frames to avoid audio buffer under-run (crackling). Improves performance at the expense of visual smoothness. 'Auto' skips frames when advised by the frontend. 'Manual' utilises the 'Frameskip Threshold (%)' setting.",
+      {
+         { "disabled", NULL },
+         { "auto",     "Auto" },
+         { "manual",   "Manual" },
+         { NULL, NULL },
+      },
+      "disabled"
+   },
+   {
+      "race_frameskip_threshold",
+      "Frameskip Threshold (%)",
+      "When 'Frameskip' is set to 'Manual', specifies the audio buffer occupancy threshold (percentage) below which frames will be skipped. Higher values reduce the risk of crackling by causing frames to be dropped more frequently.",
+      {
+         { "15", NULL },
+         { "18", NULL },
+         { "21", NULL },
+         { "24", NULL },
+         { "27", NULL },
+         { "30", NULL },
+         { "33", NULL },
+         { "36", NULL },
+         { "39", NULL },
+         { "42", NULL },
+         { "45", NULL },
+         { "48", NULL },
+         { "51", NULL },
+         { "54", NULL },
+         { "57", NULL },
+         { "60", NULL },
+         { NULL, NULL },
+      },
+      "33"
    },
    { NULL, NULL, NULL, {{0}}, NULL },
 };

--- a/tlcs900h.c
+++ b/tlcs900h.c
@@ -8410,21 +8410,7 @@ static int tlcs_step(void)
 extern unsigned char *ngpScY;
 int ngOverflow = 0;
 
-#define FRAME_RATE_LIMIT  //should we limit the framerate or let it run wild?
-#define FRAMESKIP    //undef this to do no FRAME skipping
-
 #ifdef FRAMESKIP
-//#define AUTO_FRAMESKIP
-//#define FIXED_FRAMESKIP 1
-//#define MAX_SKIPFRAMES 2
-#endif
-
-#ifdef __LIBRETRO__
-#define FIXED_FRAMESKIP 0
-int frame=FIXED_FRAMESKIP;
-#endif
-
-#ifdef AUTO_FRAMESKIP
 void tlcs_execute(int cycles, int skipFrames)// skipFrames=how many frames to skip for each frame rendered
 #else
 void tlcs_execute(int cycles)
@@ -8434,12 +8420,7 @@ void tlcs_execute(int cycles)
     int hCounter = ngOverflow;
 
 #ifdef FRAMESKIP
-#ifdef FIXED_FRAMESKIP
-//    static int frame=FIXED_FRAMESKIP;
-#else
-
-    static int frame=1;
-#endif
+    int frame = skipFrames;
 #endif
 
     while(cycles > 0)
@@ -8499,19 +8480,12 @@ void tlcs_execute(int cycles)
                 if (tlcsMemReadB(0x8000)&0x80)
                     tlcs_interrupt(2);
 #ifdef FRAMESKIP
-#ifdef FIXED_FRAMESKIP
-
-                if(frame == 0)
-                    frame = FIXED_FRAMESKIP;
-#else
-
                 if(frame == 0)
                 {
                     frame = skipFrames;
-                    SDL_Rect numRect = drawNumber(skipFrames, 10, 24);
+                    //SDL_Rect numRect = drawNumber(skipFrames, 10, 24);
                     //SDL_UpdateRect(screen, numRect.x, numRect.y, numRect.w, numRect.h);
                 }
-#endif
                 else
                     frame--;
 #endif
@@ -8533,13 +8507,13 @@ void tlcs_execute(int cycles)
 //Flavor, this auto-frameskip code is messed up
 void ngpc_run(void)
 {
-#ifdef AUTO_FRAMESKIP
+#ifdef FRAMESKIP
     unsigned int skipFrames=0;
-#endif /* AUTO_FRAMESKIP */
+#endif /* FRAMESKIP */
 
     while(m_bIsActive)  //should be some way to exit
     {
-#ifdef AUTO_FRAMESKIP
+#ifdef FRAMESKIP
         tlcs_execute((6*1024*1024) / HOST_FPS, skipFrames);
 #else
         tlcs_execute((6*1024*1024) / HOST_FPS);

--- a/tlcs900h.h
+++ b/tlcs900h.h
@@ -16,6 +16,8 @@
 extern "C" {
 #endif
 
+#define FRAMESKIP //undef this to do no FRAME skipping
+
 extern unsigned char *rasterY;
 extern unsigned int gen_regsPC, gen_regsSR;
 extern unsigned char F2;
@@ -60,7 +62,7 @@ void tlcs_reinit(void);
 /* execute interrupt */
 void tlcs_interrupt_wrapper(int irq);
 void ngpc_run(void);
-#ifdef AUTO_FRAMESKIP
+#ifdef FRAMESKIP
 void tlcs_execute(int cycles, int skipFrames); /* skipFrames=how many frames to skip for each frame rendered */
 #else
 void tlcs_execute(int cycles);


### PR DESCRIPTION
This PR adds optional automatic frame skipping based on frontend audio buffer occupancy. A new `Frameskip` option has the following values:

- `OFF`
- `Auto`: Skips frames when the frontend reports that a buffer underrun is likely
- `Manual`: Skips frames when the audio buffer occupancy is below the percentage set via the new `Frameskip Threshold (%)` core option

With `Frameskip` set to `Auto`, many games are playable even on bottom-tier hardware such as the RS-90